### PR TITLE
feat: update Sidebar styles and add title for spaces section

### DIFF
--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -1,13 +1,12 @@
 .sidebar {
-  background: linear-gradient(135deg, #9F283B 0%, #B8324A 50%, #8B1E2F 100%);
+  background: linear-gradient(135deg, #9f283b 0%, #b8324a 50%, #8b1e2f 100%);
   width: 250px;
   height: calc(100vh - 70px);
   top: 70px;
   position: fixed;
   left: 0;
   padding: 20px;
-  box-shadow: 
-    inset -2px 0 10px rgba(0, 0, 0, 0.1),
+  box-shadow: inset -2px 0 10px rgba(0, 0, 0, 0.1),
     4px 0 20px rgba(0, 0, 0, 0.15);
   border-right: 1px solid rgba(255, 255, 255, 0.1);
   backdrop-filter: blur(10px);
@@ -19,7 +18,7 @@
   margin: 15px 0;
   width: 100%;
 }
- 
+
 .sidebar-container {
   display: flex;
   flex-direction: column;
@@ -31,6 +30,15 @@
   text-align: left;
   padding: 5px 0;
   cursor: pointer;
+}
+
+.sidebar-spaces-title {
+  color: white;
+  text-align: center;
+  font-weight: 900;
+  font-size: 14px;
+  margin: 5px 0 8px 0;
+  opacity: 0.9;
 }
 
 .sidebar-item:hover {
@@ -83,4 +91,3 @@
   color: white;
   text-align: center;
 }
-

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -84,6 +84,7 @@ const Sidebar: React.FC<SidebarProps> = ({ spaces, onSpaceClick }) => {
           Explorar
         </div>
         <div className="sidebar-separator"></div>
+        <div className='sidebar-spaces-title'>Tus Spaces ✨</div>
         {spaces.map((space) => {
           const isActive = selectedSpace && space.id === selectedSpace.id && currentUser?.spaces?.some(s => s.id === space.id);
           return (


### PR DESCRIPTION
This pull request introduces a small UI enhancement to the sidebar component by adding a new section title for the user's spaces, along with minor CSS improvements.

**Sidebar UI improvements:**

* Added a new `.sidebar-spaces-title` element and corresponding CSS styles to display the "Tus Spaces ✨" section title above the user's spaces in the sidebar. [[1]](diffhunk://#diff-9a8e7714f9d7c2c36b78900abecba14232bc218b61e5cb3181c5ac73bd0709efR87) [[2]](diffhunk://#diff-8c5a2073d34c2c09063c52c726bd0a58a615040a1239cfc4e6e86cc90bd3f0c4R35-R43)
* Minor CSS cleanup: standardized hex color casing and formatting, and removed an unnecessary line break. [[1]](diffhunk://#diff-8c5a2073d34c2c09063c52c726bd0a58a615040a1239cfc4e6e86cc90bd3f0c4L2-R9) [[2]](diffhunk://#diff-8c5a2073d34c2c09063c52c726bd0a58a615040a1239cfc4e6e86cc90bd3f0c4L86)