### PR TITLE
feat: add WelcomeModal component and integrate it into the Explore page

### DIFF
--- a/src/components/modals/WelcomeModal/WelcomeModal.css
+++ b/src/components/modals/WelcomeModal/WelcomeModal.css
@@ -1,0 +1,126 @@
+.welcome-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1100;
+  opacity: 0;
+  animation: overlayFadeIn 240ms ease forwards;
+  backdrop-filter: blur(1px);
+}
+
+.welcome-modal {
+  width: 92%;
+  max-width: 640px;
+  background: white;
+  border-radius: 14px;
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
+  overflow: hidden;
+  transform-origin: center bottom;
+  opacity: 0;
+  transform: translateY(6px) scale(0.995);
+  animation: welcomeIn 260ms cubic-bezier(0.23, 0.9, 0.28, 1) forwards;
+}
+
+@keyframes overlayFadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+@keyframes welcomeIn {
+  from {
+    opacity: 0;
+    transform: translateY(6px) scale(0.995);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0) scale(1);
+  }
+}
+
+.welcome-header {
+  padding: 22px 28px;
+  background: linear-gradient(135deg, #9f283b 0%, #b8324a 100%);
+  color: white;
+}
+
+.welcome-header {
+  transform: translateY(-3px);
+  opacity: 1;
+  /* subtle header entrance — shorter and smaller */
+  animation: headerIn 220ms ease 80ms forwards;
+}
+
+.welcome-header h2 {
+  margin: 0;
+  font-size: 20px;
+}
+
+.welcome-body {
+  padding: 20px 24px;
+  color: #333;
+  line-height: 1.5;
+}
+
+.welcome-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  padding: 16px 24px 24px;
+  background: #fafafa;
+}
+
+.welcome-btn-primary {
+  background: #9f283b;
+  color: white;
+  border: none;
+  padding: 10px 18px;
+  border-radius: 10px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.welcome-btn-primary {
+  box-shadow: 0 6px 18px rgba(159, 40, 59, 0.12);
+  transition: transform 160ms ease, box-shadow 160ms ease, filter 160ms ease;
+}
+
+.welcome-btn-secondary {
+  background: transparent;
+  color: #4a5568;
+  border: 1px solid #e2e8f0;
+  padding: 10px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.welcome-btn-secondary {
+  transition: transform 160ms ease, background 160ms ease, color 160ms ease;
+}
+
+@keyframes headerIn {
+  from {
+    transform: translateY(-3px);
+    opacity: 0.9;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+.welcome-btn-primary:hover {
+  transform: translateY(-2px) scale(1.02);
+  filter: brightness(1.03);
+}
+
+.welcome-btn-secondary:hover {
+  transform: translateY(-2px);
+  background: rgba(0, 0, 0, 0.03);
+}

--- a/src/components/modals/WelcomeModal/WelcomeModal.tsx
+++ b/src/components/modals/WelcomeModal/WelcomeModal.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import './WelcomeModal.css';
+
+interface WelcomeModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const WelcomeModal: React.FC<WelcomeModalProps> = ({ isOpen, onClose }) => {
+  if (!isOpen) return null;
+
+  return (
+    <div className="welcome-overlay" onClick={onClose}>
+      <div className="welcome-modal" onClick={(e) => e.stopPropagation()}>
+        <div className="welcome-header">
+          <h2>Bienvenido a CPIHub 🎉</h2>
+        </div>
+        <div className="welcome-body">
+          <p>
+            ¡Genial que te hayas unido! En CPIHub podés seguir y suscribirte a
+            los spaces que más te interesen para empezar a ver contenido y
+            participar en conversaciones con otros usuarios.
+          </p>
+          <p>
+            Te recomendamos explorar los espacios destacados y unirte a los que
+            te llamen la atención. Si querés, también podés crear uno propio y
+            comenzar tu propia comunidad.
+          </p>
+        </div>
+        <div className="welcome-actions">
+          <button className="welcome-btn-primary" onClick={onClose}>
+            Empezar a explorar
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WelcomeModal;

--- a/src/pages/Auth/Register.tsx
+++ b/src/pages/Auth/Register.tsx
@@ -48,6 +48,14 @@ function Register() {
         }
       }
 
+      // Mark that we should show the welcome modal on the next page (single session)
+      try {
+        sessionStorage.setItem('showWelcome', '1');
+      } catch (e) {
+        // ignore sessionStorage errors (e.g., privacy mode)
+        console.warn('sessionStorage set failed:', e);
+      }
+
       navigate('/explorar');
     } catch (err) {
       if (err instanceof Error) {

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -115,7 +115,7 @@ const Explore: React.FC = () => {
 
     try {
       const shouldShow = sessionStorage.getItem('showWelcome');
-      if (true) {
+      if (shouldShow) {
         setShowWelcomeModal(true);
         sessionStorage.removeItem('showWelcome');
       }

--- a/src/pages/Explore/Explore.tsx
+++ b/src/pages/Explore/Explore.tsx
@@ -6,6 +6,7 @@ import { useNavigate } from "react-router-dom";
 import { getSpacesByCreatedAt, getSpacesByUpdatedAt, createSpace, GetSpacesByName } from "../../api";
 import type { Space } from "../../types/space";
 import CreateSpaceModal from "@components/modals/CreateSpaceModal/CreateSpaceModal";
+import WelcomeModal from "@components/modals/WelcomeModal/WelcomeModal";
 import "./Explore.css";
 
 const Explore: React.FC = () => {
@@ -16,6 +17,7 @@ const Explore: React.FC = () => {
   const [loading, setLoading] = useState(true);
   const [isCreateSpaceModalOpen, setIsCreateSpaceModalOpen] = useState(false);
   const [isCreatingSpace, setIsCreatingSpace] = useState(false);
+  const [showWelcomeModal, setShowWelcomeModal] = useState(false);
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [spacesWithSameName, setSpacesWithSameName] = useState<Space[]>([]);
   const [pendingSpace, setPendingSpace] = useState<{ name: string; description: string } | null>(null);
@@ -110,6 +112,16 @@ const Explore: React.FC = () => {
     };
 
     fetchSpaces();
+
+    try {
+      const shouldShow = sessionStorage.getItem('showWelcome');
+      if (true) {
+        setShowWelcomeModal(true);
+        sessionStorage.removeItem('showWelcome');
+      }
+    } catch (err) {
+      console.warn('sessionStorage access failed:', err);
+    }
   }, []);
 
   const handleSpaceClick = (space: Space) => {
@@ -224,6 +236,11 @@ const Explore: React.FC = () => {
               onClose={closeCreateSpaceModal}
               onCreateSpace={handleCreateSpace}
               isLoading={isCreatingSpace}
+            />
+
+            <WelcomeModal
+              isOpen={showWelcomeModal}
+              onClose={() => setShowWelcomeModal(false)}
             />
 
             {showConfirmModal && (


### PR DESCRIPTION
This pull request introduces a new welcome modal that is shown to users immediately after registration, enhancing the onboarding experience. The modal provides a brief introduction and encourages users to explore or create spaces. The implementation uses session storage to ensure the modal is only shown once after registration.

**User onboarding improvements:**

* Added a new `WelcomeModal` React component (`WelcomeModal.tsx`) with corresponding CSS for styling and animations (`WelcomeModal.css`). The modal welcomes new users and provides guidance on exploring or creating spaces. [[1]](diffhunk://#diff-6d16e1bc650219e416b598f50906b7ae9e19553f68d37b33b1f991540b14be8dR1-R40) [[2]](diffhunk://#diff-f33ff8fff97ce2ad6e5acc13c8ba6aab876364fcb268550c805f755efa0cb053R1-R126)
* Integrated the `WelcomeModal` into the `Explore` page, including state management to control its visibility. [[1]](diffhunk://#diff-14c3b01e45049e3f9a9e247b2531920927251c84cca4856bf378ea9169a7f1a2R9) [[2]](diffhunk://#diff-14c3b01e45049e3f9a9e247b2531920927251c84cca4856bf378ea9169a7f1a2R20) [[3]](diffhunk://#diff-14c3b01e45049e3f9a9e247b2531920927251c84cca4856bf378ea9169a7f1a2R241-R245)

**Session-based modal display logic:**

* On successful registration, set a `showWelcome` flag in `sessionStorage` to indicate the welcome modal should be shown on the next page load.
* On the `Explore` page, check for the `showWelcome` flag in `sessionStorage` and display the welcome modal if present, then remove the flag to prevent repeated display.